### PR TITLE
Use `yaml.FullLoader` for Safe Loading

### DIFF
--- a/properties
+++ b/properties
@@ -1,3 +1,3 @@
 version.major=1
 version.minor=1
-version.patch=1
+version.patch=2

--- a/src/setup.py
+++ b/src/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='{{ version.major }}.{{ version.minor }}.{{ version.patch }}',
+    version='1.1.2',
 
     description='A helper library that allows hierarchical YAML files with variable substitution.',
     long_description=long_description,

--- a/src/setup.py
+++ b/src/setup.py
@@ -71,7 +71,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'click<6.7',
-        'pyyaml<3.13',
+        'pyyaml<6.0>3.13',
         'jinja2<2.9',
     ],
 

--- a/src/templated_yaml/cli.py
+++ b/src/templated_yaml/cli.py
@@ -12,7 +12,7 @@ def cli(ctx):
 @click.argument('path', required=False, type=click.Path(exists=True))
 @click.option('--context', default="---")
 def render(path, context):
-    context = yaml.load(context)
+    context = yaml.load(context, Loader=yaml.FullLoader)
 
     if path:
         click.echo(yaml.dump(api.render_from_path(path, context), default_flow_style=False))

--- a/src/templated_yaml/resolver.py
+++ b/src/templated_yaml/resolver.py
@@ -69,7 +69,7 @@ class TYamlResolver(object):
         yaml_source = None
 
         with open(abs_path, 'r') as stream:
-            yaml_source = yaml.load(stream)
+            yaml_source = yaml.load(stream, Loader=yaml.FullLoader)
 
         resolver = TYamlResolver(yaml_source, **kwargs)
         resolver._original_file = abs_path
@@ -78,7 +78,7 @@ class TYamlResolver(object):
 
     @classmethod
     def new_from_string(cls, content, **kwargs):
-        resolver = TYamlResolver(yaml.load(content), **kwargs)
+        resolver = TYamlResolver(yaml.load(content, Loader=yaml.FullLoader), **kwargs)
         resolver._original_file = None
 
         return resolver


### PR DESCRIPTION
This patch makes use of `yaml.FullLoader` instead of `yaml.UnsafeLoader` which is used by default, see [here](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) for an explanation.

Note that this requires a current `pyyaml` version (5.1 at the moment).